### PR TITLE
Add disk option on spatie downloader

### DIFF
--- a/src/Helpers/IdNumberHelper.php
+++ b/src/Helpers/IdNumberHelper.php
@@ -8,8 +8,8 @@ use Illuminate\Support\Str;
 class IdNumberHelper
 {
     /**
-     * @param $dateOfBirth 19821208
-     * @param  int  $male 0 or 1
+     * @param  $dateOfBirth  19821208
+     * @param  int  $male  0 or 1
      *
      * @throws \Exception
      */

--- a/src/Helpers/SpatieMediaHelper.php
+++ b/src/Helpers/SpatieMediaHelper.php
@@ -38,7 +38,11 @@ class SpatieMediaHelper
 
     public static function download(Media $media, bool $asFilename = false, $disk = null): StreamedResponse|Media
     {
-        return Storage::disk($disk ?? $media->disk)->download($media->getPath(), ($asFilename) ? $media->name : $media->file_name);
+        if(!is_null($disk)) {
+            return Storage::disk($disk)->download($media->getPath(), ($asFilename) ? $media->name : $media->file_name);
+        }
+
+        return Storage::download($media->getPath(), ($asFilename) ? $media->name : $media->file_name);
     }
 
     public static function delete(Media $media): ?bool

--- a/src/Helpers/SpatieMediaHelper.php
+++ b/src/Helpers/SpatieMediaHelper.php
@@ -2,6 +2,7 @@
 
 namespace PropaySystems\Utilities\Helpers;
 
+use Illuminate\Support\Facades\Storage;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -35,10 +36,9 @@ class SpatieMediaHelper
             ->toMediaCollection($collection, $disk);
     }
 
-    public static function download(Media $media, bool $asFilename = false): StreamedResponse|Media
+    public static function download(Media $media, bool $asFilename = false, $disk = null): StreamedResponse|Media
     {
-        return $media;
-        //return Storage::download($media->getPath(), ($asFilename) ? $media->file_name : $media->name);
+        return Storage::disk($disk ?? $media->disk)->download($media->getPath(), ($asFilename) ? $media->name : $media->file_name);
     }
 
     public static function delete(Media $media): ?bool

--- a/src/Helpers/SpatieMediaHelper.php
+++ b/src/Helpers/SpatieMediaHelper.php
@@ -38,7 +38,7 @@ class SpatieMediaHelper
 
     public static function download(Media $media, bool $asFilename = false, $disk = null): StreamedResponse|Media
     {
-        if(!is_null($disk)) {
+        if (! is_null($disk)) {
             return Storage::disk($disk)->download($media->getPath(), ($asFilename) ? $media->name : $media->file_name);
         }
 

--- a/src/Traits/TriggerHelper.php
+++ b/src/Traits/TriggerHelper.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\DB;
 trait TriggerHelper
 {
     /**
-     * @param $state
+     * @param  $state
      */
     public static function switchDatabaseTrigger($enable = true, $table = null, $trigger = null, string $connection = 'sqlsrv'): void
     {

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -2,6 +2,4 @@
 
 namespace PropaySystems\Utilities;
 
-class Utilities
-{
-}
+class Utilities {}


### PR DESCRIPTION
Add disk option to download media. To be used to download file as original filename instead of generated filename