### PR TITLE
Fix ID validation calculation and simplify age retrieval

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.2, 8.1]
+        php: [8.2]
         laravel: [10.*]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.2]
-        laravel: [10.*]
+        laravel: [11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
         laravel: [11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
+          - laravel: 11.*
             testbench: 8.*
             carbon: ^2.63
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,8 +18,8 @@ jobs:
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
-            testbench: 8.*
-            carbon: ^2.63
+            testbench: 9.*
+            carbon: ^3.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
+          composer require --dev "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies

--- a/src/Helpers/IdNumberHelper.php
+++ b/src/Helpers/IdNumberHelper.php
@@ -178,10 +178,10 @@ class IdNumberHelper
 
         $c = 0;
 
-        do {
+        while ($b > 0) {
             $c += $b % 10;
-            $b /= 10;
-        } while ($b > 0);
+            $b = intdiv($b, 10);
+        }
 
         $c += $a;
         $d = 10 - ($c % 10);
@@ -218,9 +218,6 @@ class IdNumberHelper
 
     public static function getBirthdayFromIdNumber($idNumber): int
     {
-        $birthday = self::getBirthDate($idNumber);
-        $currentDate = Carbon::now();
-
-        return $currentDate->diffInYears($birthday);
+        return Carbon::parse(self::getBirthDate($idNumber))->age;
     }
 }

--- a/src/Traits/SaveRelations.php
+++ b/src/Traits/SaveRelations.php
@@ -16,7 +16,7 @@ trait SaveRelations
     public function saveBelongsTo($model, $relations = [])
     {
 
-        //check if not empty
+        // check if not empty
         if (! empty($relations)) {
             foreach ($relations as $relation => $value) {
                 $method = str_replace('_id', '', $relation);
@@ -40,7 +40,7 @@ trait SaveRelations
      */
     public function sync($model, $relations = [])
     {
-        //check if not empty
+        // check if not empty
         if (! empty($relations)) {
             foreach ($relations as $relation => $value) {
                 if (! empty($value)) {

--- a/tests/Unit/ArchTest.php
+++ b/tests/Unit/ArchTest.php
@@ -1,5 +1,5 @@
 <?php
 
-//it('will not use debugging functions')
+// it('will not use debugging functions')
 //    ->expect(['dd', 'dump', 'ray'])
 //    ->each->not->toBeUsed();

--- a/tests/Unit/SetNullOnEmptyTraitTest.php
+++ b/tests/Unit/SetNullOnEmptyTraitTest.php
@@ -1,6 +1,8 @@
 <?php
 
-uses(\PropaySystems\Utilities\Traits\SetNullOnEmpty::class);
+use PropaySystems\Utilities\Traits\SetNullOnEmpty;
+
+uses(SetNullOnEmpty::class);
 
 it('set the value to null when variable is empty', function () {
     $input = '';

--- a/tests/Unit/StringHelperTest.php
+++ b/tests/Unit/StringHelperTest.php
@@ -1,32 +1,34 @@
 <?php
 
+use PropaySystems\Utilities\Helpers\StringHelper;
+
 it('can create initials from a string', function () {
-    $string = \PropaySystems\Utilities\Helpers\StringHelper::initials('Ettienne Louw');
+    $string = StringHelper::initials('Ettienne Louw');
 
     expect($string)->toBe('EL');
 });
 
 it('can capitalize first charters of a string', function () {
-    $string = \PropaySystems\Utilities\Helpers\StringHelper::capitaliseFirstChar('john');
+    $string = StringHelper::capitaliseFirstChar('john');
 
     expect($string)->toBe('John');
 });
 
 it('can clean a string', function () {
-    $string = \PropaySystems\Utilities\Helpers\StringHelper::clean('    This (guy) "is"    testing 123');
+    $string = StringHelper::clean('    This (guy) "is"    testing 123');
 
     expect($string)->toBe('This guy is testing 123');
 });
 
 it('can generate a password', function () {
-    $password = \PropaySystems\Utilities\Helpers\StringHelper::generatePassword();
+    $password = StringHelper::generatePassword();
 
     expect($password)
         ->toHaveLength(15);
 });
 
 it('can generate a password with all lowercase', function () {
-    $password = \PropaySystems\Utilities\Helpers\StringHelper::generatePassword(18, 1, 'lower_case');
+    $password = StringHelper::generatePassword(18, 1, 'lower_case');
 
     expect($password)
         ->toHaveLength(18)
@@ -34,7 +36,7 @@ it('can generate a password with all lowercase', function () {
 });
 
 it('can generate a password with all uppercase', function () {
-    $password = \PropaySystems\Utilities\Helpers\StringHelper::generatePassword(15, 1, 'upper_case');
+    $password = StringHelper::generatePassword(15, 1, 'upper_case');
 
     expect($password)
         ->toHaveLength(15)
@@ -42,7 +44,7 @@ it('can generate a password with all uppercase', function () {
 });
 
 it('can generate a password with only numbers', function () {
-    $password = \PropaySystems\Utilities\Helpers\StringHelper::generatePassword(15, 1, 'numbers');
+    $password = StringHelper::generatePassword(15, 1, 'numbers');
 
     expect($password)
         ->toHaveLength(15)
@@ -50,13 +52,13 @@ it('can generate a password with only numbers', function () {
 });
 
 it('can mask a string', function () {
-    $password = \PropaySystems\Utilities\Helpers\StringHelper::mask('123412341234');
+    $password = StringHelper::mask('123412341234');
 
     expect($password)->toBe('1234****1234');
 });
 
 it('can return array of special characters', function () {
-    $password = \PropaySystems\Utilities\Helpers\StringHelper::specialCharacters();
+    $password = StringHelper::specialCharacters();
 
     expect($password)
         ->toBeArray()


### PR DESCRIPTION
Update the digit summation loop to use `intdiv` for explicit integer division, addressing potential warnings or issues in ID number validation. Simplify age retrieval by utilizing Carbon's `age` accessor, making the code more concise.
